### PR TITLE
get uri scheme from environment

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,7 +10,7 @@ export default class Auth {
 
   private constructor() {
     this._options = {
-      redirectUri: config.auth.callbackUrl,
+      redirectUri: `${vscode.env.uriScheme}://${config.auth.callbackUrl}`,
       responseType: config.auth.responseType,
     };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ const config = {
   auth: {
     domain: 'codelingo.au.auth0.com',
     clientId: 'GcFxVITN0O8ZJn82C9zJ8uuz8e63kUPz',
-    callbackUrl: 'vscode://codelingo.codelingo/authorize',
+    callbackUrl: 'codelingo.codelingo/authorize',
     responseType: 'token id_token',
     scope: 'openid email profile',
     audience: 'https://flow.codelingo.io',


### PR DESCRIPTION
I believe this will fix the problem that Marc has been having. He is running the insiders version of VSCode which uses the 'vscode-insiders://' scheme as opposed to 'vscode://'. API exposes this, so use it.