### PR TITLE
Resume capture after login

### DIFF
--- a/src/capture/command.ts
+++ b/src/capture/command.ts
@@ -7,6 +7,17 @@ import axios from 'axios';
 import { Commit } from '../@types/git';
 import Auth from '../auth';
 
+let captureWasInterrupted = false;
+
+export function shouldResumeCapture(): boolean {
+  if (captureWasInterrupted) {
+    captureWasInterrupted = false;
+    return true;
+  }
+
+  return false;
+}
+
 export default async function capture(): Promise<any> {
   const auth = Auth.getInstance();
   if (!auth.accessToken) {
@@ -14,6 +25,8 @@ export default async function capture(): Promise<any> {
     if (!ok) {
       return ui.errorNotLoggedIn();
     }
+
+    captureWasInterrupted = true; // signal to continue capture after authentication completes
     return await auth.authenticate();
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import { ExtensionContext, workspace, commands, window, Uri, ProviderResult } from 'vscode';
-import capture from './capture/command';
+import capture, { shouldResumeCapture } from './capture/command';
 import * as git from './git';
 import * as ui from './ui';
 import Auth from './auth';
@@ -19,6 +19,10 @@ export async function activate(context: ExtensionContext): Promise<void> {
         const auth = Auth.getInstance();
         auth.accessToken = token;
         window.showInformationMessage('Login Successful');
+
+        if (shouldResumeCapture()) {
+          commands.executeCommand('codelingo.capture');
+        }
       }
     },
   });


### PR DESCRIPTION
When authentication is needed, the capture command now automatically resumes from where it was interrupted.